### PR TITLE
create issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contribution Guidelines
+
+Thank you for your interest in contributing to Uni-Dock! We value your time and effort, and aim to make the contribution process enjoyable and efficient. To ensure consistency and maintainability, please follow these guidelines when submitting your contributions.
+
+## Troubleshooting
+
+If you encountered problems using Uni-Dock, please refer to our GitHub [issue tracker](https://github.com/dptech-corp/Uni-Dock/issues), and check if it is a known problem.
+If you found a bug, you can help us improve by [submitting a new issue](https://github.com/dptech-corp/Uni-Dock/issues/new) to our GitHub Repository. Provide a clear and concise title and description, including steps to reproduce the issue (if applicable) and any relevant context.
+Even better, you can submit a Pull Request with a patch.
+
+## Feature requests
+
+We highly appreciate your contributions, and would like to help you crafting the changes and making contributions to the community.
+If you would like to implement a new feature, please **submit a feature requesting issue with a proposal for your work first**. 
+This help fitting your ideas and work with the development road map well, coordinating our efforts, and avoiding duplication of work.
+
+## Submitting a Pull Request
+
+**Please fork your own copy of the Uni-Dock repository, and draft your changes there.** Once the modified codes work as expected, please submit a pull request to merge your contributions.
+
+1. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) the [Uni-Dock repository](https://github.com/dptech-corp/Uni-Dock). If you already had an existing fork, [sync](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) the fork to keep your modification up-to-date.
+
+2. Pull your forked repository, create a new git branch, and make your changes in it:
+
+     ```shell
+     git checkout -b bug-fix
+     ```
+
+3. Coding your patch and commit the changes.
+
+4. Push your branch to GitHub:
+
+    ```shell
+    git push origin my-fix-branch
+    ```
+
+5. On GitHub, create a pull request (PR) from your bug-fix branch targeting `dptech-corp/Uni-Dock`.
+ 
+6. After your pull request is merged, you can safely delete your branch and sync the changes from the main (upstream) repository:
+
+- Delete the remote branch on GitHub either [through the GitHub web UI](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/deleting-and-restoring-branches-in-a-pull-request#deleting-a-branch-used-for-a-pull-request) or your local shell as follows:
+
+    ```shell
+    git push origin --delete my-fix-branch
+    ```
+
+- Check out the master branch:
+
+    ```shell
+    git checkout develop -f
+    ```
+
+- Delete the local branch:
+
+    ```shell
+    git branch -D my-fix-branch
+    ```
+
+- Update your master with the latest upstream version:
+
+    ```shell
+    git pull --ff upstream develop
+    ```

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+Please provide necessary information including input file, running commands, error log, etc.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Environment (please complete the following information):**
+ - CUDA version
+ - GPU model
+ - Uni-Dock version
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This PR adds issue templates to provide an skeleton for the user to report bugs and filing feature requests.
The content is based on the default template from GitHub, and I think it is enough for most cases.
For bug reports, we ask the user to provide info with their GPU hardware and software setup.